### PR TITLE
Vis datoer i periode uansett

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5155,6 +5155,12 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "moment": {
+          "version": "2.24.0",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+          "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+          "dev": true
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -10530,12 +10536,6 @@
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
-    },
-    "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
-      "dev": true
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/src/components/sporsmal/typer/periode-komp.tsx
+++ b/src/components/sporsmal/typer/periode-komp.tsx
@@ -1,6 +1,7 @@
+import dayjs from 'dayjs'
 import { Norwegian } from 'flatpickr/dist/l10n/no.js'
 import { Normaltekst } from 'nav-frontend-typografi'
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import Flatpickr from 'react-flatpickr'
 import { Controller, useFormContext } from 'react-hook-form'
 
@@ -20,14 +21,26 @@ type AllProps = SpmProps & PeriodeProps;
 
 const PeriodeKomp = ({ sporsmal, index, slettPeriode }: AllProps) => {
     const { setValue, errors, getValues } = useFormContext()
+    const [ datoer, settDatoer ] = useState<Date[]>([])
     const id = sporsmal.id + '_' + index
     const htmlfor = sporsmal.id + '_t_' + index
     const feilmelding = hentFeilmelding(sporsmal)
+    Norwegian.rangeSeparator = ' - '
 
     useEffect(() => {
         setValue(id, hentPeriode(sporsmal, index))
         // eslint-disable-next-line
     }, [ sporsmal ]);
+
+    const onValueUpdate = (selectedDates: Date[]) => {
+        if (selectedDates.length > 0) {
+            settDatoer(selectedDates)
+        }
+    }
+
+    const formater = () => {
+        return datoer.map(dato => dayjs(dato).format('DD.MM.YYYY')).join('   -    ')
+    }
 
     return (
         <li className='periode'>
@@ -49,6 +62,7 @@ const PeriodeKomp = ({ sporsmal, index, slettPeriode }: AllProps) => {
                 name={id}
                 className='skjemaelement__input input--m'
                 placeholder='dd.mm.åååå - dd.mm.åååå'
+                onValueUpdate={onValueUpdate}
                 options={{
                     minDate: sporsmal.min,
                     maxDate: sporsmal.max,
@@ -57,6 +71,7 @@ const PeriodeKomp = ({ sporsmal, index, slettPeriode }: AllProps) => {
                     dateFormat: 'F j, Y',
                     altInput: true,
                     altFormat: 'd.m.Y',
+                    formatDate: formater,
                     locale: Norwegian,
                     allowInput: true,
                     disableMobile: true


### PR DESCRIPTION
Endringer i denne committen:

* Datoer vises i perioden uansett, selv om fom og tom er like
* Periode-separatoren er ` - `, hvis en bruker vil skrive inn datoen manuelt, kan man skrive `17.05.1990 - 17.05.1990`. Dette parses til datoer.
* Når en periode er satt, vil det stå som `17.05.1990<tre mellomromstegn>-<fire mellomromstegn>17.05.1990`. Dette for å forsøke å aligne datoene med "fra og med" og "til og med" labels