### PR TITLE
Fjerner feilmeldinger fra syfosoknad manuelt

### DIFF
--- a/src/components/sporsmal/sporsmal-form/sporsmal-form.tsx
+++ b/src/components/sporsmal/sporsmal-form/sporsmal-form.tsx
@@ -191,6 +191,10 @@ const SporsmalForm = () => {
         }
     }
 
+    const preSubmit = () => {
+        methods.clearErrors('syfosoknad')
+    }
+
     const onSubmit = async() => {
         if (poster) return
         setPoster(true)
@@ -240,6 +244,7 @@ const SporsmalForm = () => {
     return (
         <FormProvider {...methods}>
             <form onSubmit={methods.handleSubmit(onSubmit)}
+                onSubmitCapture={preSubmit}
                 className={'sporsmal__form ' + nesteSporsmal?.tag?.toLowerCase()}>
 
                 <BjornUnderTittel sporsmal={sporsmal} />


### PR DESCRIPTION
Når feilmeldinger kommer tilbake fra syfosoknad, så settes en feilmelding i form.
Denne blir ikke revalidert da den ikke hører til noe input, og onSubmit kjører bare hvis det ikke er feilmeldinger i form