### PR TITLE
Flytt oppsummering nederst

### DIFF
--- a/src/components/sporsmal/sporsmal-form/sporsmal-form.tsx
+++ b/src/components/sporsmal/sporsmal-form/sporsmal-form.tsx
@@ -23,6 +23,7 @@ import fetcher from '../../../utils/fetcher'
 import { logger } from '../../../utils/logger'
 import { useAmplitudeInstance } from '../../amplitude/amplitude'
 import FeilOppsummering from '../../feil/feil-oppsummering'
+import Opplysninger from '../../opplysninger-fra-sykmelding/opplysninger'
 import Oppsummering from '../../oppsummering/oppsummering'
 import Vis from '../../vis'
 import BjornOverSporsmalstekst from '../bjorn/bjorn-over-sporsmalstekst'
@@ -259,6 +260,8 @@ const SporsmalForm = () => {
                 <Vis hvis={erSiste && !erUtlandssoknad}
                     render={() =>
                         <>
+                            <Oppsummering ekspandert={false} />
+                            <Opplysninger ekspandert={false} steg={sporsmal.tag} />
                             <CheckboxPanel sporsmal={nesteSporsmal} />
                             <SendesTil />
                         </>

--- a/src/pages/soknad/soknaden.tsx
+++ b/src/pages/soknad/soknaden.tsx
@@ -14,7 +14,6 @@ import { hentHotjarJsTrigger, HotjarTrigger } from '../../components/hotjar-trig
 import HvorforSoknadSykepenger from '../../components/hvorfor-soknad-sykepenger/hvorfor-soknad-sykepenger'
 import OmReisetilskudd from '../../components/om-reisetilskudd/om-reisetilskudd'
 import Opplysninger from '../../components/opplysninger-fra-sykmelding/opplysninger'
-import Oppsummering from '../../components/oppsummering/oppsummering'
 import { ViktigInformasjon } from '../../components/soknad-intro/viktig-informasjon'
 import SoknadMedToDeler from '../../components/soknad-med-to-deler/soknad-med-to-deler'
 import SporsmalForm from '../../components/sporsmal/sporsmal-form/sporsmal-form'
@@ -144,18 +143,12 @@ const Fordeling = () => {
                         }
                     />
 
-                    <Vis hvis={!erUtlandssoknad && (stegNo == 1 || stegNo == valgtSoknad!.sporsmal.length-1)}
+                    <Vis hvis={!erUtlandssoknad && (stegNo === 1)}
                         render={
                             () => {
-                                const sporsmal = valgtSoknad!.sporsmal[stegNo - 1]
-                                return <Opplysninger ekspandert={stegNo == 1} steg={sporsmal.tag} />
+                                const sporsmal = valgtSoknad!.sporsmal[ stegNo - 1 ]
+                                return <Opplysninger ekspandert={true} steg={sporsmal.tag} />
                             }}
-                    />
-
-                    <Vis hvis={!erUtlandssoknad && stegNo == valgtSoknad!.sporsmal.length-1}
-                        render={() =>
-                            <Oppsummering ekspandert={false} />
-                        }
                     />
 
                     <Vis hvis={stegNo === 1 && !erUtlandssoknad}


### PR DESCRIPTION
Flyttet bokser med Opplysninger og Oppsumering ned under infotekst
på siste side og byttet rekkefølgen så den er lik rekkefølge og plasering
på kvitteringssiden.